### PR TITLE
 Fix array to string conversion error

### DIFF
--- a/src/lara-crud/Crud/MigrationCrud.php
+++ b/src/lara-crud/Crud/MigrationCrud.php
@@ -136,7 +136,7 @@ class MigrationCrud implements Crud
             }
             //for enum data type we will use in validator.
             if ($dataType == 'enum') {
-                $retVals = str_replace(",", "','", $column->options());
+                $retVals = join("', '", $column->options());
                 $params = '[\'' . $retVals . '\']';
             } elseif ($dataType == 'varchar') {
                 $params = $column->length();


### PR DESCRIPTION
Fix array to string conversion error when generating migration for table with enum fields.